### PR TITLE
feat(web): add task link panel

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@ import project from "./project";
 import { getPublicProject } from "./project/controllers/get-public-project";
 import search from "./search";
 import task from "./task";
+import taskLink from "./task-link";
 import timeEntry from "./time-entry";
 import user from "./user";
 import { validateSessionToken } from "./user/utils/validate-session-token";
@@ -103,6 +104,7 @@ const workspaceRoute = app.route("/workspace", workspace);
 const workspaceUserRoute = app.route("/workspace-user", workspaceUser);
 const projectRoute = app.route("/project", project);
 const taskRoute = app.route("/task", task);
+const taskLinkRoute = app.route("/task-link", taskLink);
 const activityRoute = app.route("/activity", activity);
 const timeEntryRoute = app.route("/time-entry", timeEntry);
 const labelRoute = app.route("/label", label);
@@ -134,6 +136,7 @@ export type AppType =
   | typeof workspaceUserRoute
   | typeof projectRoute
   | typeof taskRoute
+  | typeof taskLinkRoute
   | typeof activityRoute
   | typeof meRoute
   | typeof timeEntryRoute

--- a/apps/api/src/label/controllers/create-label.ts
+++ b/apps/api/src/label/controllers/create-label.ts
@@ -1,11 +1,27 @@
+import { HTTPException } from "hono/http-exception";
 import db from "../../database";
-import { labelTable } from "../../database/schema";
+import { labelTable, taskLabelTable } from "../../database/schema";
 
 async function createLabel(name: string, color: string, taskId: string) {
+  const task = await db.query.taskTable.findFirst({
+    where: (t, { eq }) => eq(t.id, taskId),
+    with: { project: true },
+  });
+
+  if (!task?.project) {
+    throw new HTTPException(404, { message: "Task not found" });
+  }
+
   const [label] = await db
     .insert(labelTable)
-    .values({ name, color, taskId })
+    .values({
+      name,
+      color,
+      workspaceId: task.project.workspaceId,
+    })
     .returning();
+
+  await db.insert(taskLabelTable).values({ taskId, labelId: label.id });
 
   return label;
 }

--- a/apps/api/src/label/controllers/get-labels-by-task-id.ts
+++ b/apps/api/src/label/controllers/get-labels-by-task-id.ts
@@ -1,11 +1,15 @@
+import { eq } from "drizzle-orm";
 import db from "../../database";
+import { labelTable, taskLabelTable } from "../../database/schema";
 
 async function getLabelsByTaskId(taskId: string) {
-  const labels = await db.query.labelTable.findMany({
-    where: (label, { eq }) => eq(label.taskId, taskId),
-  });
+  const rows = await db
+    .select({ label: labelTable })
+    .from(labelTable)
+    .innerJoin(taskLabelTable, eq(taskLabelTable.labelId, labelTable.id))
+    .where(eq(taskLabelTable.taskId, taskId));
 
-  return labels;
+  return rows.map((row) => row.label);
 }
 
 export default getLabelsByTaskId;

--- a/apps/web/src/components/kanban-board/task-labels.tsx
+++ b/apps/web/src/components/kanban-board/task-labels.tsx
@@ -28,8 +28,8 @@ type Label = {
   id: string;
   name: string;
   color: string;
-  taskId: string;
   createdAt: string;
+  workspaceId: string;
 };
 
 function TaskCardLabels({ taskId }: { taskId: string }) {

--- a/apps/web/src/components/task/task-info.tsx
+++ b/apps/web/src/components/task/task-info.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import { z } from "zod/v4";
 import TaskCalendar from "./task-calendar";
 import TaskLabels from "./task-labels";
+import TaskLinkPanel from "./task-link-panel";
 
 export const taskInfoSchema = z.object({
   status: z.string(),
@@ -209,6 +210,7 @@ function TaskInfo({
           )}
         />
         <TaskLabels taskId={task.id} setIsSaving={setIsSaving} />
+        <TaskLinkPanel taskId={task.id} />
       </Form>
       <Button
         onClick={handleDeleteTask}

--- a/apps/web/src/components/task/task-labels.tsx
+++ b/apps/web/src/components/task/task-labels.tsx
@@ -38,7 +38,6 @@ type Label = {
   id: string;
   name: string;
   color: string;
-  taskId: string;
   createdAt: string;
 };
 

--- a/apps/web/src/components/task/task-link-panel.tsx
+++ b/apps/web/src/components/task/task-link-panel.tsx
@@ -1,0 +1,154 @@
+import { Button } from "@/components/ui/button";
+import { FormItem, FormLabel } from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import useCreateTaskLink from "@/hooks/mutations/task-link/use-create-task-link";
+import useDeleteTaskLink from "@/hooks/mutations/task-link/use-delete-task-link";
+import useGetTaskLinks from "@/hooks/queries/task-link/use-get-task-links";
+import { generateLink } from "@/lib/generate-link";
+import useProjectStore from "@/store/project";
+import type { TaskLink, TaskLinkType } from "@/types/task-link";
+import { Copy, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface TaskLinkPanelProps {
+  taskId: string;
+}
+
+export default function TaskLinkPanel({ taskId }: TaskLinkPanelProps) {
+  const { project } = useProjectStore();
+  const { data: links = [] } = useGetTaskLinks(taskId);
+  const { mutateAsync: createLink } = useCreateTaskLink();
+  const { mutateAsync: deleteLink } = useDeleteTaskLink();
+  const [targetTask, setTargetTask] = useState("");
+  const [linkType, setLinkType] = useState<TaskLinkType>("relates_to");
+
+  const tasks = project?.columns?.flatMap((col) => col.tasks) ?? [];
+  const options = tasks.filter((t) => t.id !== taskId);
+
+  const handleAddLink = async () => {
+    if (!targetTask) return;
+    try {
+      await createLink({
+        taskId,
+        targetTaskId: targetTask,
+        type: linkType,
+      });
+      setTargetTask("");
+      setLinkType("relates_to");
+      toast.success("Task linked");
+    } catch (error) {
+      toast.error("Failed to link task");
+    }
+  };
+
+  const handleCopy = (id: string) => {
+    if (!project) return;
+    const path = `/dashboard/workspace/${project.workspaceId}/project/${project.id}/task/${id}`;
+    const link = generateLink(path);
+    navigator.clipboard.writeText(link);
+    toast.success("Task link copied!");
+  };
+
+  const handleDelete = async (linkId: string) => {
+    try {
+      await deleteLink({ taskId, linkId });
+      toast.success("Link removed");
+    } catch (error) {
+      toast.error("Failed to remove link");
+    }
+  };
+
+  const getLinkedTask = (link: TaskLink) => {
+    const otherId =
+      link.fromTaskId === taskId ? link.toTaskId : link.fromTaskId;
+    return tasks.find((t) => t.id === otherId);
+  };
+
+  return (
+    <FormItem className="mt-4">
+      <FormLabel>Linked Tasks</FormLabel>
+      <div className="space-y-2">
+        {links.map((link: TaskLink) => {
+          const task = getLinkedTask(link);
+          if (!task) return null;
+          return (
+            <div
+              key={link.id}
+              className="flex items-center justify-between text-sm"
+            >
+              <span>
+                {task.title} ({link.type.replace(/_/g, " ")})
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleCopy(task.id)}
+                  aria-label="Copy task link"
+                >
+                  <Copy className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleDelete(link.id)}
+                  aria-label="Remove link"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+        <div className="flex items-center gap-2">
+          <Select
+            value={linkType}
+            onValueChange={(v: TaskLinkType) => setLinkType(v)}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Select type" />
+            </SelectTrigger>
+            <SelectContent>
+              {(
+                [
+                  "blocks",
+                  "blocked_by",
+                  "relates_to",
+                  "duplicates",
+                  "parent",
+                  "child",
+                ] as TaskLinkType[]
+              ).map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type.replace(/_/g, " ")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={targetTask} onValueChange={setTargetTask}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Select task" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((task) => (
+                <SelectItem key={task.id} value={task.id}>
+                  {task.title}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button onClick={handleAddLink} disabled={!targetTask}>
+            Add
+          </Button>
+        </div>
+      </div>
+    </FormItem>
+  );
+}

--- a/apps/web/src/fetchers/task-link/create-task-link.ts
+++ b/apps/web/src/fetchers/task-link/create-task-link.ts
@@ -1,0 +1,23 @@
+import type { TaskLinkType } from "@/types/task-link";
+import { client } from "@kaneo/libs";
+
+async function createTaskLink(
+  taskId: string,
+  targetTaskId: string,
+  type: TaskLinkType = "relates_to",
+) {
+  // biome-ignore lint/suspicious/noExplicitAny: task-link route not typed
+  const response = await (client as any)["task-link"][":taskId"].$post({
+    param: { taskId },
+    json: { targetTaskId, type },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  return await response.json();
+}
+
+export default createTaskLink;

--- a/apps/web/src/fetchers/task-link/delete-task-link.ts
+++ b/apps/web/src/fetchers/task-link/delete-task-link.ts
@@ -1,0 +1,19 @@
+import { client } from "@kaneo/libs";
+
+async function deleteTaskLink(taskId: string, linkId: string) {
+  // biome-ignore lint/suspicious/noExplicitAny: task-link route not typed
+  const response = await (client as any)["task-link"][":taskId"][
+    ":linkId"
+  ].$delete({
+    param: { taskId, linkId },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  return await response.json();
+}
+
+export default deleteTaskLink;

--- a/apps/web/src/fetchers/task-link/get-task-links.ts
+++ b/apps/web/src/fetchers/task-link/get-task-links.ts
@@ -1,0 +1,17 @@
+import { client } from "@kaneo/libs";
+
+async function getTaskLinks(taskId: string) {
+  // biome-ignore lint/suspicious/noExplicitAny: task-link route not typed
+  const response = await (client as any)["task-link"][":taskId"].$get({
+    param: { taskId },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  return await response.json();
+}
+
+export default getTaskLinks;

--- a/apps/web/src/hooks/mutations/task-link/use-create-task-link.ts
+++ b/apps/web/src/hooks/mutations/task-link/use-create-task-link.ts
@@ -1,0 +1,26 @@
+import createTaskLink from "@/fetchers/task-link/create-task-link";
+import type { TaskLinkType } from "@/types/task-link";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+function useCreateTaskLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      taskId,
+      targetTaskId,
+      type,
+    }: {
+      taskId: string;
+      targetTaskId: string;
+      type: TaskLinkType;
+    }) => createTaskLink(taskId, targetTaskId, type),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["task-links", variables.taskId],
+      });
+    },
+  });
+}
+
+export default useCreateTaskLink;

--- a/apps/web/src/hooks/mutations/task-link/use-delete-task-link.ts
+++ b/apps/web/src/hooks/mutations/task-link/use-delete-task-link.ts
@@ -1,0 +1,18 @@
+import deleteTaskLink from "@/fetchers/task-link/delete-task-link";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+function useDeleteTaskLink() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ taskId, linkId }: { taskId: string; linkId: string }) =>
+      deleteTaskLink(taskId, linkId),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["task-links", variables.taskId],
+      });
+    },
+  });
+}
+
+export default useDeleteTaskLink;

--- a/apps/web/src/hooks/queries/task-link/use-get-task-links.ts
+++ b/apps/web/src/hooks/queries/task-link/use-get-task-links.ts
@@ -1,0 +1,12 @@
+import getTaskLinks from "@/fetchers/task-link/get-task-links";
+import { useQuery } from "@tanstack/react-query";
+
+function useGetTaskLinks(taskId: string) {
+  return useQuery({
+    queryKey: ["task-links", taskId],
+    queryFn: () => getTaskLinks(taskId),
+    enabled: !!taskId,
+  });
+}
+
+export default useGetTaskLinks;

--- a/apps/web/src/types/task-link.ts
+++ b/apps/web/src/types/task-link.ts
@@ -1,0 +1,17 @@
+export type TaskLinkType =
+  | "blocks"
+  | "blocked_by"
+  | "relates_to"
+  | "duplicates"
+  | "parent"
+  | "child";
+
+export interface TaskLink {
+  id: string;
+  fromTaskId: string;
+  toTaskId: string;
+  type: TaskLinkType;
+  createdAt: string;
+  createdBy: string;
+  direction: "out" | "in" | "undirected";
+}


### PR DESCRIPTION
## Summary
- add `TaskLinkPanel` to link tasks with selectable relationship and copy/delete actions
- use `TaskLinkPanel` on task details page
- align label components and API with schema

## Testing
- `pnpm --filter @kaneo/api lint`
- `pnpm --filter @kaneo/web lint`
- `pnpm --filter @kaneo/web build`


------
https://chatgpt.com/codex/tasks/task_e_689df92301588324935f4c49a7b54e61